### PR TITLE
Improve tooling and add OCR-D CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2
+
+jobs:
+
+  build-python36:
+    docker:
+      - image: python:3.6
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - model-cache
+      - run: make model
+      - save_cache:
+          key: model-cache
+          paths:
+            models.tar.gz
+            models
+      - run: make install
+      - run: git submodule update --init
+      - run: make test
+
+  build-python37:
+    docker:
+      - image: python:3.7
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - model-cache
+      - run: make model
+      - save_cache:
+          key: model-cache
+          paths:
+            models.tar.gz
+            models
+      - run: make install
+      - run: git submodule update --init
+      - run: make test
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-python36
+      - build-python37
+      #- build-python38 # no tensorflow for python 3.8

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+__pycache__

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "repo/assets"]
+	path = repo/assets
+	url = https://github.com/OCR-D/assets

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: install
+
+install:
+	pip install .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,36 @@
-all: install
+# Directory to store models
+MODEL_DIR = $(PWD)/models
 
+# BEGIN-EVAL makefile-parser --make-help Makefile
+
+help:
+	@echo ""
+	@echo "  Targets"
+	@echo ""
+	@echo "    install  Install with pip"
+	@echo "    model    Downloads the pre-trained models from qurator-data.de"
+	@echo "    test     Run tests"
+	@echo ""
+	@echo "  Variables"
+	@echo ""
+	@echo "    MODEL_DIR  Directory to store models"
+
+# END-EVAL
+
+# Install with pip
 install:
 	pip install .
+
+# Downloads the pre-trained models from qurator-data.de
+model: $(MODEL_DIR)/model1_bin.h5
+
+$(MODEL_DIR)/model1_bin.h5: models.tar.gz
+	tar xf models.tar.gz
+
+models.tar.gz:
+	wget 'https://qurator-data.de/sbb_binarization/models.tar.gz'
+
+# Run tests
+test: model
+	cd repo/assets/data/kant_aufklaerung_1784/data; ocrd-sbb-binarize -I OCR-D-IMG -O BIN -P model $(MODEL_DIR)
+	cd repo/assets/data/kant_aufklaerung_1784-page-region/data; ocrd-sbb-binarize -I OCR-D-IMG -O BIN -P model $(MODEL_DIR) -P level-of-operation region

--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
 # Binarization
+
 > Binarization for document images
 
 ## Introduction
-This tool performs document image binarization (i.e. transform colour/grayscale to black-and-white pixels) for OCR using multiple trained models.
+
+This tool performs document image binarization (i.e. transform colour/grayscale
+to black-and-white pixels) for OCR using multiple trained models.
 
 ## Installation
+
 Clone the repository, enter it and run  
-`./make`
+
+`pip install .`
 
 ### Models
+
 Pre-trained models can be downloaded from here:   
+
 https://qurator-data.de/sbb_binarization/
 
 ## Usage 
-`sbb_binarize -m <directory with models> -i <image file> 
--p <set to true to let the model see the image divided into patches> 
--s <directory where the results will be saved>`
+
+```sh
+sbb_binarize \
+  -m <directory with models> \
+  -i <image file> \
+  -p <set to true to let the model see the image divided into patches> \
+  -s <directory where the results will be saved>`
+```

--- a/ocrd-tool.json
+++ b/ocrd-tool.json
@@ -1,0 +1,1 @@
+sbb_binarize/ocrd-tool.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+numpy >= 1.17.0, < 1.19.0
+setuptools >= 41
 opencv-python-headless
-numpy
+ocrd >= 2.18.0
 keras >= 2.3.1, < 2.4
 tensorflow >= 1.15, < 1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python-headless
+numpy
+keras >= 2.3.1, < 2.4
+tensorflow >= 1.15, < 1.16

--- a/sbb_binarize/cli.py
+++ b/sbb_binarize/cli.py
@@ -2,22 +2,15 @@
 sbb_binarize CLI
 """
 
-from argparse import ArgumentParser
+from click import command, option, argument, version_option
 
 from .sbb_binarize import SbbBinarizer
 
-def main():
-    parser = ArgumentParser()
-
-    parser.add_argument('-i', '--image', default=None, help='image.')
-    parser.add_argument('-p', '--patches', default=False, help='by setting this parameter to true you let the model to see the image in patches.')
-    parser.add_argument('-s', '--save', default=False, help='save prediction with a given name here. The name and format should be given (outputname.tif).')
-    parser.add_argument('-m', '--model', default=None, help='models directory.')
-
-    options = parser.parse_args()
-
-    binarizer = SbbBinarizer(model_dir=options.model)
-    binarizer.run(image_path=options.image, patches=options.patches, save=options.save)
-
-if __name__ == "__main__":
-    main()
+@command()
+@version_option()
+@option('--patches/--no-patches', default=True, help='by enabling this parameter you let the model to see the image in patches.')
+@option('--model-dir', '-m', required=True, help='directory containing models for prediction')
+@argument('input_image')
+@argument('output_image')
+def main(patches, model_dir, input_image, output_image):
+    SbbBinarizer(model_dir).run(image_path=input_image, use_patches=patches, save=output_image)

--- a/sbb_binarize/cli.py
+++ b/sbb_binarize/cli.py
@@ -16,13 +16,8 @@ def main():
 
     options = parser.parse_args()
 
-    binarizer = SbbBinarizer(
-            image_path=options.image,
-            model=options.model,
-            patches=options.patches,
-            save=options.save
-    )
-    binarizer.run()
+    binarizer = SbbBinarizer(model_dir=options.model)
+    binarizer.run(image_path=options.image, patches=options.patches, save=options.save)
 
 if __name__ == "__main__":
     main()

--- a/sbb_binarize/cli.py
+++ b/sbb_binarize/cli.py
@@ -16,7 +16,12 @@ def main():
 
     options = parser.parse_args()
 
-    binarizer = SbbBinarizer(options.image, options.model, options.patches, options.save)
+    binarizer = SbbBinarizer(
+            image_path=options.image,
+            model=options.model,
+            patches=options.patches,
+            save=options.save
+    )
     binarizer.run()
 
 if __name__ == "__main__":

--- a/sbb_binarize/cli.py
+++ b/sbb_binarize/cli.py
@@ -1,0 +1,23 @@
+"""
+sbb_binarize CLI
+"""
+
+from argparse import ArgumentParser
+
+from .sbb_binarize import SbbBinarizer
+
+def main():
+    parser = ArgumentParser()
+
+    parser.add_argument('-i', '--image', default=None, help='image.')
+    parser.add_argument('-p', '--patches', default=False, help='by setting this parameter to true you let the model to see the image in patches.')
+    parser.add_argument('-s', '--save', default=False, help='save prediction with a given name here. The name and format should be given (outputname.tif).')
+    parser.add_argument('-m', '--model', default=None, help='models directory.')
+
+    options = parser.parse_args()
+
+    binarizer = SbbBinarizer(options.image, options.model, options.patches, options.save)
+    binarizer.run()
+
+if __name__ == "__main__":
+    main()

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -4,7 +4,7 @@
   "tools": {
     "ocrd-sbb-binarize": {
       "executable": "ocrd-sbb-binarize",
-      "description": "Smart binarization with sbb_binarization",
+      "description": "Pixelwise binarization with selectional auto-encoders in Keras",
       "categories": ["Image preprocessing"],
       "steps": ["preprocessing/optimization/binarization"],
       "input_file_grp": [],

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -16,11 +16,6 @@
           "default": "page",
           "description": "PAGE XML hierarchy level to operate on"
         },
-        "patches": {
-          "description": "by setting this parameter to true you let the model to see the image in patches.",
-          "type": "boolean",
-          "default": true
-        },
         "model": {
           "description": "models directory.",
           "type": "string",

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -19,7 +19,7 @@
         "patches": {
           "description": "by setting this parameter to true you let the model to see the image in patches.",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "model": {
           "description": "models directory.",

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -14,7 +14,7 @@
           "type": "string",
           "enum": ["page", "region", "line"],
           "default": "page",
-          "description": "PAGE XML hierarchy level to operate on (currently only page supported"
+          "description": "PAGE XML hierarchy level to operate on"
         },
         "patches": {
           "description": "by setting this parameter to true you let the model to see the image in patches.",

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -10,6 +10,12 @@
       "input_file_grp": [],
       "output_file_grp": [],
       "parameters": {
+        "operation_level": {
+          "type": "string",
+          "enum": ["page", "region", "line"],
+          "default": "page",
+          "description": "PAGE XML hierarchy level to operate on (currently only page supported"
+        },
         "patches": {
           "description": "by setting this parameter to true you let the model to see the image in patches.",
           "type": "boolean",
@@ -17,7 +23,7 @@
         },
         "model": {
           "description": "models directory.",
-          "format": "string",
+          "type": "string",
           "required": true
         }
       }

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.0.1",
+  "git_url": "https://github.com/qurator-spk/sbb_binarization",
+  "tools": {
+    "ocrd-sbb-binarize": {
+      "executable": "ocrd-sbb-binarize",
+      "description": "Smart binarization with sbb_binarization",
+      "categories": ["Image preprocessing"],
+      "steps": ["preprocessing/optimization/binarization"],
+      "input_file_grp": [],
+      "output_file_grp": [],
+      "parameters": {
+        "patches": {
+          "description": "by setting this parameter to true you let the model to see the image in patches.",
+          "type": "boolean",
+          "default": false
+        },
+        "model": {
+          "description": "models directory.",
+          "format": "string",
+          "required": true
+        }
+      }
+    }
+  }
+}

--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -12,7 +12,7 @@
       "parameters": {
         "operation_level": {
           "type": "string",
-          "enum": ["page", "region", "line"],
+          "enum": ["page", "region"],
           "default": "page",
           "description": "PAGE XML hierarchy level to operate on"
         },

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -80,7 +80,7 @@ class SbbBinarizeProcessor(Processor):
                         file_id + '.IMG-BIN',
                         page_id=input_file.pageId,
                         file_grp=self.output_file_grp)
-                page.add_AlternativeImage(AlternativeImageType(filename=bin_image_path, comment="binarized"))
+                page.add_AlternativeImage(AlternativeImageType(filename=bin_image_path, comment=page_xywh['features']+",binarized"))
 
             else:
                 regions = page.get_AllRegions(['Text', 'Table'])
@@ -98,7 +98,7 @@ class SbbBinarizeProcessor(Processor):
                                 page_id=input_file.pageId,
                                 file_grp=self.output_file_grp)
                         region.add_AlternativeImage(
-                            AlternativeImageType(filename=region_image_bin_path, comments='binarized'))
+                            AlternativeImageType(filename=region_image_bin_path, comments=region_xywh['features']+',binarized'))
 
                     elif oplevel == 'line':
                         lines = region.get_TextLine()
@@ -113,7 +113,7 @@ class SbbBinarizeProcessor(Processor):
                                     page_id=input_file.pageId,
                                     file_grp=self.output_file_grp)
                             line.add_AlternativeImage(
-                                AlternativeImageType(filename=line_image_bin_path, comments='binarized'))
+                                AlternativeImageType(filename=line_image_bin_path, comments=line_xywh['features']+',binarized'))
 
             self.workspace.add_file(
                 ID=file_id,

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -50,7 +50,7 @@ class SbbBinarizeProcessor(Processor):
         oplevel = self.parameter['operation_level']
         use_patches = self.parameter['patches'] # pylint: disable=attribute-defined-outside-init
         model_path = self.parameter['model'] # pylint: disable=attribute-defined-outside-init
-        binarizer = SbbBinarizer(model_dir=self.model_path)
+        binarizer = SbbBinarizer(model_dir=model_path)
 
         for n, input_file in enumerate(self.input_files):
             file_id = make_file_id(input_file, self.output_file_grp)
@@ -64,7 +64,7 @@ class SbbBinarizeProcessor(Processor):
             if oplevel == 'page':
                 LOG.info("Binarizing on 'page' level in page '%s'", page_id)
                 page_image, page_xywh, _ = self.workspace.image_from_page(page, page_id, feature_filter='binarized')
-                bin_image = cv2pil(binarizer.run(image=pil2cv(page_image), patches=use_patches))
+                bin_image = cv2pil(binarizer.run(image=pil2cv(page_image), use_patches=use_patches))
                 # update METS (add the image file):
                 bin_image_path = self.workspace.save_image_file(bin_image,
                         file_id + '.IMG-BIN',
@@ -78,7 +78,7 @@ class SbbBinarizeProcessor(Processor):
                     LOG.warning("Page '%s' contains no text/table regions", page_id)
                 for region in regions:
                     region_image, region_xywh = self.workspace.image_from_segment(region, page_image, page_xywh, feature_filter='binarized')
-                    region_image_bin = cv2pil(binarizer.run(image=pil2cv(region_image), patches=use_patches))
+                    region_image_bin = cv2pil(binarizer.run(image=pil2cv(region_image), use_patches=use_patches))
                     region_image_bin_path = self.workspace.save_image_file(
                             region_image_bin,
                             "%s_%s.IMG-BIN" % (file_id, region.id),
@@ -93,7 +93,7 @@ class SbbBinarizeProcessor(Processor):
                     LOG.warning("Page '%s' contains no text lines", page_id)
                 for region_id, line in region_line_tuples:
                     line_image, line_xywh = self.workspace.image_from_segment(line, page_image, page_xywh, feature_filter='binarized')
-                    line_image_bin = cv2pil(binarizer.run(image=pil2cv(line_image), patches=use_patches))
+                    line_image_bin = cv2pil(binarizer.run(image=pil2cv(line_image), use_patches=use_patches))
                     line_image_bin_path = self.workspace.save_image_file(
                             line_image_bin,
                             "%s_%s_%s.IMG-BIN" % (file_id, region_id, line.id),

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -78,7 +78,7 @@ class SbbBinarizeProcessor(Processor):
                 # update METS (add the image file):
                 bin_image_path = self.workspace.save_image_file(bin_image,
                         file_id + '.IMG-BIN',
-                        page_id=page_id,
+                        page_id=input_file.pageId,
                         file_grp=self.output_file_grp)
                 page.add_AlternativeImage(AlternativeImageType(filename=bin_image_path, comment="binarized"))
 
@@ -95,7 +95,7 @@ class SbbBinarizeProcessor(Processor):
                         region_image_bin_path = self.workspace.save_image_file(
                                 region_image_bin,
                                 "%s_%s.IMG-BIN" % (file_id, region.id),
-                                page_id=page_id,
+                                page_id=input_file.pageId,
                                 file_grp=self.output_file_grp)
                         region.add_AlternativeImage(
                             AlternativeImageType(filename=region_image_bin_path, comments='binarized'))
@@ -110,7 +110,7 @@ class SbbBinarizeProcessor(Processor):
                             line_image_bin_path = self.workspace.save_image_file(
                                     line_image_bin,
                                     "%s_%s_%s.IMG-BIN" % (file_id, region.id, line.id),
-                                    page_id=page_id,
+                                    page_id=input_file.pageId,
                                     file_grp=self.output_file_grp)
                             line.add_AlternativeImage(
                                 AlternativeImageType(filename=line_image_bin_path, comments='binarized'))

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -4,15 +4,17 @@ import os.path
 from pkg_resources import resource_string
 from json import loads
 
+from click import command
 from ocrd_utils import (
     getLogger,
     assert_file_grp_cardinality,
     make_file_id,
     MIMETYPE_PAGE
 )
+from ocrd import Processor
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import AlternativeImageType, to_xml
-from ocrd import Processor
+from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 
 from .sbb_binarize import SbbBinarizer
 
@@ -113,3 +115,8 @@ class SbbBinarizeProcessor(Processor):
                 mimetype=MIMETYPE_PAGE,
                 local_filename=os.path.join(self.output_file_grp, file_id + '.xml'),
                 content=to_xml(pcgts))
+
+@command()
+@ocrd_cli_options
+def cli(*args, **kwargs):
+    return ocrd_cli_wrap_processor(SbbBinarizeProcessor, *args, **kwargs)

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -73,7 +73,7 @@ class SbbBinarizeProcessor(Processor):
 
             if oplevel == 'page':
                 LOG.info("Binarizing on 'page' level in page '%s'", page_id)
-                page_image, page_xywh, _ = self.workspace.image_from_page(page, page_id)
+                page_image, page_xywh, _ = self.workspace.image_from_page(page, page_id, feature_filter='binarized')
                 bin_image = self._run_binarizer(page_image)
                 # update METS (add the image file):
                 bin_image_path = self.workspace.save_image_file(bin_image,
@@ -88,7 +88,7 @@ class SbbBinarizeProcessor(Processor):
                     LOG.warning("Page '%s' contains no text/table regions", page_id)
 
                 for region in regions:
-                    region_image, region_xywh = self.workspace.image_from_segment(region, page_image, page_xywh)
+                    region_image, region_xywh = self.workspace.image_from_segment(region, page_image, page_xywh, feature_filter='binarized')
 
                     if oplevel == 'region':
                         region_image_bin = self._run_binarizer(region_image)
@@ -105,7 +105,7 @@ class SbbBinarizeProcessor(Processor):
                         if not lines:
                             LOG.warning("Page '%s' region '%s' contains no text lines", page_id, region.id)
                         for line in lines:
-                            line_image, line_xywh = self.workspace.image_from_segment(line, page_image, page_xywh)
+                            line_image, line_xywh = self.workspace.image_from_segment(line, page_image, page_xywh, feature_filter='binarized')
                             line_image_bin = self._run_binarizer(line_image)
                             line_image_bin_path = self.workspace.save_image_file(
                                     line_image_bin,

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -1,0 +1,75 @@
+import os.path
+from pkg_resources import resource_string
+from json import loads
+
+from ocrd_utils import (
+    getLogger,
+    assert_file_grp_cardinality,
+    make_file_id,
+    MIMETYPE_PAGE
+)
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import (
+    MetadataItemType,
+    LabelsType, LabelType,
+    AlternativeImageType,
+    TextRegionType,
+    to_xml
+)
+from ocrd import Processor
+
+from .sbb_binarize import SbbBinarizer
+
+OCRD_TOOL = loads(resource_string(__name__, 'ocrd-tool.json').decode('utf8'))
+TOOL = 'ocrd-sbb-binarize'
+
+class SbbBinarizeProcessor(Processor):
+
+    def __init__(self, *args, **kwargs):
+        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
+        kwargs['version'] = OCRD_TOOL['version']
+        super().__init__(*args, **kwargs)
+
+    def process(self):
+        """
+        Binarize with sbb_binarization
+        """
+        LOG = getLogger('processor.SbbBinarize')
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
+
+        oplevel = self.parameter['operation_level']
+        use_patches = self.parameter['patches']
+        model_path = self.parameter['model']
+
+        for n, input_file in enumerate(self.input_files):
+            file_id = make_file_id(input_file, self.output_file_grp)
+            page_id = input_file.pageId or input_file.ID
+            LOG.info("INPUT FILE %i / %s", n, page_id)
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            self.add_metadata(pcgts)
+            page = pcgts.get_Page()
+
+            if oplevel == 'page':
+                LOG.info("Binarizing on 'page' level in page '%s'", page_id)
+                page_image, page_xywh, _ = self.workspace.image_from_page(page, page_id)
+                binarizer = SbbBinarizer(image=page_image, model=model_path, patches=use_patches, save=None)
+                bin_image = binarizer.run()
+                # update METS (add the image file):
+                bin_image_path = self.workspace.save_image_file(bin_image,
+                        file_id + '.IMG-BIN',
+                        page_id=page_id,
+                        file_grp=self.output_file_grp)
+                page.add_AlternativeImage(filename=bin_image_path, comment="binarized")
+            else:
+                raise NotImplementedError("Binarization below page level not implemented yet")
+
+            file_id = make_file_id(input_file, self.output_file_grp)
+            pcgts.set_pcGtsId(file_id)
+            self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                mimetype=MIMETYPE_PAGE,
+                local_filename=os.path.join(self.output_file_grp, file_id + '.xml'),
+                content=to_xml(pcgts))

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -48,7 +48,6 @@ class SbbBinarizeProcessor(Processor):
         assert_file_grp_cardinality(self.output_file_grp, 1)
 
         oplevel = self.parameter['operation_level']
-        use_patches = self.parameter['patches'] # pylint: disable=attribute-defined-outside-init
         model_path = self.parameter['model'] # pylint: disable=attribute-defined-outside-init
         binarizer = SbbBinarizer(model_dir=model_path)
 
@@ -64,7 +63,7 @@ class SbbBinarizeProcessor(Processor):
             if oplevel == 'page':
                 LOG.info("Binarizing on 'page' level in page '%s'", page_id)
                 page_image, page_xywh, _ = self.workspace.image_from_page(page, page_id, feature_filter='binarized')
-                bin_image = cv2pil(binarizer.run(image=pil2cv(page_image), use_patches=use_patches))
+                bin_image = cv2pil(binarizer.run(image=pil2cv(page_image), use_patches=True))
                 # update METS (add the image file):
                 bin_image_path = self.workspace.save_image_file(bin_image,
                         file_id + '.IMG-BIN',
@@ -78,7 +77,7 @@ class SbbBinarizeProcessor(Processor):
                     LOG.warning("Page '%s' contains no text/table regions", page_id)
                 for region in regions:
                     region_image, region_xywh = self.workspace.image_from_segment(region, page_image, page_xywh, feature_filter='binarized')
-                    region_image_bin = cv2pil(binarizer.run(image=pil2cv(region_image), use_patches=use_patches))
+                    region_image_bin = cv2pil(binarizer.run(image=pil2cv(region_image), use_patches=True))
                     region_image_bin_path = self.workspace.save_image_file(
                             region_image_bin,
                             "%s_%s.IMG-BIN" % (file_id, region.id),
@@ -93,7 +92,7 @@ class SbbBinarizeProcessor(Processor):
                     LOG.warning("Page '%s' contains no text lines", page_id)
                 for region_id, line in region_line_tuples:
                     line_image, line_xywh = self.workspace.image_from_segment(line, page_image, page_xywh, feature_filter='binarized')
-                    line_image_bin = cv2pil(binarizer.run(image=pil2cv(line_image), use_patches=use_patches))
+                    line_image_bin = cv2pil(binarizer.run(image=pil2cv(line_image), use_patches=True))
                     line_image_bin_path = self.workspace.save_image_file(
                             line_image_bin,
                             "%s_%s_%s.IMG-BIN" % (file_id, region_id, line.id),

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -24,7 +24,7 @@ OCRD_TOOL = loads(resource_string(__name__, 'ocrd-tool.json').decode('utf8'))
 TOOL = 'ocrd-sbb-binarize'
 
 def cv2pil(img):
-    return Image.fromarray(img.as_type('uint8'))
+    return Image.fromarray(img.astype('uint8'))
 
 def pil2cv(img):
     # from ocrd/workspace.py

--- a/sbb_binarize/ocrd_cli.py
+++ b/sbb_binarize/ocrd_cli.py
@@ -1,5 +1,3 @@
-# TODO: AlternativeImage 'binarized' comment should be additive
-
 import os.path
 from pkg_resources import resource_string
 from json import loads
@@ -26,8 +24,7 @@ OCRD_TOOL = loads(resource_string(__name__, 'ocrd-tool.json').decode('utf8'))
 TOOL = 'ocrd-sbb-binarize'
 
 def cv2pil(img):
-    color_coverted = cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)
-    return Image.fromarray(color_coverted)
+    return Image.fromarray(img.as_type('uint8'))
 
 def pil2cv(img):
     # from ocrd/workspace.py
@@ -80,7 +77,7 @@ class SbbBinarizeProcessor(Processor):
                         file_id + '.IMG-BIN',
                         page_id=input_file.pageId,
                         file_grp=self.output_file_grp)
-                page.add_AlternativeImage(AlternativeImageType(filename=bin_image_path, comment=page_xywh['features']+",binarized"))
+                page.add_AlternativeImage(AlternativeImageType(filename=bin_image_path, comment='%s,binarized' % page_xywh['features']))
 
             else:
                 regions = page.get_AllRegions(['Text', 'Table'])
@@ -98,7 +95,7 @@ class SbbBinarizeProcessor(Processor):
                                 page_id=input_file.pageId,
                                 file_grp=self.output_file_grp)
                         region.add_AlternativeImage(
-                            AlternativeImageType(filename=region_image_bin_path, comments=region_xywh['features']+',binarized'))
+                            AlternativeImageType(filename=region_image_bin_path, comments='%s,binarized' % region_xywh['features']))
 
                     elif oplevel == 'line':
                         lines = region.get_TextLine()
@@ -113,7 +110,7 @@ class SbbBinarizeProcessor(Processor):
                                     page_id=input_file.pageId,
                                     file_grp=self.output_file_grp)
                             line.add_AlternativeImage(
-                                AlternativeImageType(filename=line_image_bin_path, comments=line_xywh['features']+',binarized'))
+                                AlternativeImageType(filename=line_image_bin_path, comments='%s,binarized' % line_xywh['features']))
 
             self.workspace.add_file(
                 ID=file_id,

--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -42,10 +42,10 @@ class SbbBinarizer:
         n_classes = model.layers[len(model.layers)-1].output_shape[3]
         return model, model_height, model_width, n_classes
 
-    def predict(self, model_name, img, patches):
+    def predict(self, model_name, img, use_patches):
         model, model_height, model_width, n_classes = self.load_model(model_name)
 
-        if patches in ('true', 'True'):
+        if use_patches:
 
             margin = int(0.1 * model_width)
 
@@ -184,8 +184,7 @@ class SbbBinarizer:
             prediction_true = prediction_true.astype(np.uint8)
         return prediction_true[:,:,0]
 
-    # TODO use True/False for patches
-    def run(self, image=None, image_path=None, save=None, patches='false'):
+    def run(self, image=None, image_path=None, save=None, use_patches=False):
         if (image is not None and image_path is not None) or \
                (image is None and image_path is None):
             raise ValueError("Must pass either a opencv2 image or an image_path")
@@ -196,7 +195,7 @@ class SbbBinarizer:
         img_last = 0
         for model_in in list_of_model_files:
 
-            res = self.predict(model_in, image, patches)
+            res = self.predict(model_in, image, use_patches)
 
             img_fin = np.zeros((res.shape[0], res.shape[1], 3))
             res[:, :][res[:, :] == 0] = 2

--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -8,6 +8,7 @@ from os.path import join
 from warnings import catch_warnings, simplefilter
 
 import numpy as np
+from PIL import Image
 import cv2
 environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 stderr = sys.stderr
@@ -23,9 +24,10 @@ class SbbBinarizer:
 
     # TODO use True/False for patches
     def __init__(self, model, image=None, image_path=None, patches='false', save=None):
-        if not(image or image_path) or (image and image_path):
-            raise ValueError("Must pass either a PIL image or an image_path")
-        if image:
+        if (image is not None and image_path is not None) or \
+               (image is None and image_path is None):
+            raise ValueError("Must pass either a opencv2 image or an image_path")
+        if image is not None:
             self.image = image
         else:
             self.image = cv2.imread(self.image)

--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -1,60 +1,57 @@
-#! /usr/bin/env python3
-
-__version__= '1.0'
-
-import argparse
-import sys
-import os
-import numpy as np
-import warnings
-import cv2
-from keras.models import load_model
-import tensorflow as tf
-
-
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    
-__doc__=\
 """
 Tool to load model and binarize a given image.
 """
 
+from argparse import ArgumentParser
+from os import listdir
+from os.path import join
+from warnings import catch_warnings, simplefilter
+
+import numpy as np
+import cv2
+from keras.models import load_model
+import tensorflow as tf
+
+# XXX better to set env var before tensorflow import to suppress those specific warnings
+with catch_warnings():
+    simplefilter("ignore")
+
 class sbb_binarize:
-    def __init__(self,image,model, patches='false',save=None ):
-        self.image=image
-        self.patches=patches
-        self.save=save
-        self.model_dir=model
+
+    # TODO use True/False for patches
+    def __init__(self, image, model, patches='false', save=None):
+        self.image = image
+        self.patches = patches
+        self.save = save
+        self.model_dir = model
 
     def resize_image(self,img_in,input_height,input_width):
-        return cv2.resize( img_in, ( input_width,input_height) ,interpolation=cv2.INTER_NEAREST)
-    
+        return cv2.resize(img_in, (input_width, input_height), interpolation=cv2.INTER_NEAREST)
+
     def start_new_session_and_model(self):
         config = tf.ConfigProto()
-        config.gpu_options.allow_growth=True
-    
-        self.session =tf.Session(config=config)# tf.InteractiveSession()
+        config.gpu_options.allow_growth = True
+
+        self.session = tf.Session(config=config)  # tf.InteractiveSession()
+
     def load_model(self,model_name):
-        self.model = load_model(self.model_dir+'/'+model_name , compile=False)
-        
-        
-        self.img_height=self.model.layers[len(self.model.layers)-1].output_shape[1]
-        self.img_width=self.model.layers[len(self.model.layers)-1].output_shape[2]
-        self.n_classes=self.model.layers[len(self.model.layers)-1].output_shape[3]
+
+        self.model = load_model(join(self.model_dir, model_name), compile=False)
+
+        self.img_height = self.model.layers[len(self.model.layers)-1].output_shape[1]
+        self.img_width = self.model.layers[len(self.model.layers)-1].output_shape[2]
+        self.n_classes = self.model.layers[len(self.model.layers)-1].output_shape[3]
 
     def end_session(self):
         self.session.close()
-
-
         del self.model
         del self.session
+
     def predict(self,model_name):
         self.load_model(model_name)
-        img=cv2.imread(self.image)
-        img_width_model=self.img_width
-        img_height_model=self.img_height
+        img = cv2.imread(self.image)
+        img_width_model = self.img_width
+        img_height_model = self.img_height
 
         if self.patches=='true' or self.patches=='True':
 
@@ -107,149 +104,135 @@ class sbb_binarize:
                     if index_y_u > img_h:
                         index_y_u = img_h
                         index_y_d = img_h - img_height_model
-                        
-                    
 
                     img_patch = img[index_y_d:index_y_u, index_x_d:index_x_u, :]
 
-                    label_p_pred = self.model.predict(
-                        img_patch.reshape(1, img_patch.shape[0], img_patch.shape[1], img_patch.shape[2]))
+                    label_p_pred = self.model.predict(img_patch.reshape(1, img_patch.shape[0], img_patch.shape[1], img_patch.shape[2]))
 
                     seg = np.argmax(label_p_pred, axis=3)[0]
 
                     seg_color = np.repeat(seg[:, :, np.newaxis], 3, axis=2)
 
-                    if i==0 and j==0:
+                    if i == 0 and j == 0:
                         seg_color = seg_color[0:seg_color.shape[0] - margin, 0:seg_color.shape[1] - margin, :]
                         seg = seg[0:seg.shape[0] - margin, 0:seg.shape[1] - margin]
 
                         mask_true[index_y_d + 0:index_y_u - margin, index_x_d + 0:index_x_u - margin] = seg
-                        prediction_true[index_y_d + 0:index_y_u - margin, index_x_d + 0:index_x_u - margin,
-                        :] = seg_color
-                        
-                    elif i==nxf-1 and j==nyf-1:
+                        prediction_true[index_y_d + 0:index_y_u - margin, index_x_d + 0:index_x_u - margin, :] = seg_color
+
+                    elif i == nxf-1 and j == nyf-1:
                         seg_color = seg_color[margin:seg_color.shape[0] - 0, margin:seg_color.shape[1] - 0, :]
                         seg = seg[margin:seg.shape[0] - 0, margin:seg.shape[1] - 0]
 
                         mask_true[index_y_d + margin:index_y_u - 0, index_x_d + margin:index_x_u - 0] = seg
-                        prediction_true[index_y_d + margin:index_y_u - 0, index_x_d + margin:index_x_u - 0,
-                        :] = seg_color
-                        
-                    elif i==0 and j==nyf-1:
+                        prediction_true[index_y_d + margin:index_y_u - 0, index_x_d + margin:index_x_u - 0, :] = seg_color
+
+                    elif i == 0 and j == nyf-1:
                         seg_color = seg_color[margin:seg_color.shape[0] - 0, 0:seg_color.shape[1] - margin, :]
                         seg = seg[margin:seg.shape[0] - 0, 0:seg.shape[1] - margin]
 
                         mask_true[index_y_d + margin:index_y_u - 0, index_x_d + 0:index_x_u - margin] = seg
-                        prediction_true[index_y_d + margin:index_y_u - 0, index_x_d + 0:index_x_u - margin,
-                        :] = seg_color
-                        
-                    elif i==nxf-1 and j==0:
+                        prediction_true[index_y_d + margin:index_y_u - 0, index_x_d + 0:index_x_u - margin, :] = seg_color
+
+                    elif i == nxf-1 and j == 0:
                         seg_color = seg_color[0:seg_color.shape[0] - margin, margin:seg_color.shape[1] - 0, :]
                         seg = seg[0:seg.shape[0] - margin, margin:seg.shape[1] - 0]
 
                         mask_true[index_y_d + 0:index_y_u - margin, index_x_d + margin:index_x_u - 0] = seg
-                        prediction_true[index_y_d + 0:index_y_u - margin, index_x_d + margin:index_x_u - 0,
-                        :] = seg_color
-                        
-                    elif i==0 and j!=0 and j!=nyf-1:
+                        prediction_true[index_y_d + 0:index_y_u - margin, index_x_d + margin:index_x_u - 0, :] = seg_color
+
+                    elif i == 0 and j != 0 and j != nyf-1:
                         seg_color = seg_color[margin:seg_color.shape[0] - margin, 0:seg_color.shape[1] - margin, :]
                         seg = seg[margin:seg.shape[0] - margin, 0:seg.shape[1] - margin]
 
                         mask_true[index_y_d + margin:index_y_u - margin, index_x_d + 0:index_x_u - margin] = seg
-                        prediction_true[index_y_d + margin:index_y_u - margin, index_x_d + 0:index_x_u - margin,
-                        :] = seg_color
-                        
-                    elif i==nxf-1 and j!=0 and j!=nyf-1:
+                        prediction_true[index_y_d + margin:index_y_u - margin, index_x_d + 0:index_x_u - margin, :] = seg_color
+
+                    elif i == nxf-1 and j != 0 and j != nyf-1:
                         seg_color = seg_color[margin:seg_color.shape[0] - margin, margin:seg_color.shape[1] - 0, :]
                         seg = seg[margin:seg.shape[0] - margin, margin:seg.shape[1] - 0]
 
                         mask_true[index_y_d + margin:index_y_u - margin, index_x_d + margin:index_x_u - 0] = seg
-                        prediction_true[index_y_d + margin:index_y_u - margin, index_x_d + margin:index_x_u - 0,
-                        :] = seg_color
-                        
-                    elif i!=0 and i!=nxf-1 and j==0:
+                        prediction_true[index_y_d + margin:index_y_u - margin, index_x_d + margin:index_x_u - 0, :] = seg_color
+
+                    elif i != 0 and i != nxf-1 and j == 0:
                         seg_color = seg_color[0:seg_color.shape[0] - margin, margin:seg_color.shape[1] - margin, :]
                         seg = seg[0:seg.shape[0] - margin, margin:seg.shape[1] - margin]
 
                         mask_true[index_y_d + 0:index_y_u - margin, index_x_d + margin:index_x_u - margin] = seg
-                        prediction_true[index_y_d + 0:index_y_u - margin, index_x_d + margin:index_x_u - margin,
-                        :] = seg_color
-                        
-                    elif i!=0 and i!=nxf-1 and j==nyf-1:
+                        prediction_true[index_y_d + 0:index_y_u - margin, index_x_d + margin:index_x_u - margin, :] = seg_color
+
+                    elif i != 0 and i != nxf-1 and j == nyf-1:
                         seg_color = seg_color[margin:seg_color.shape[0] - 0, margin:seg_color.shape[1] - margin, :]
                         seg = seg[margin:seg.shape[0] - 0, margin:seg.shape[1] - margin]
 
                         mask_true[index_y_d + margin:index_y_u - 0, index_x_d + margin:index_x_u - margin] = seg
-                        prediction_true[index_y_d + margin:index_y_u - 0, index_x_d + margin:index_x_u - margin,
-                        :] = seg_color
+                        prediction_true[index_y_d + margin:index_y_u - 0, index_x_d + margin:index_x_u - margin, :] = seg_color
 
                     else:
                         seg_color = seg_color[margin:seg_color.shape[0] - margin, margin:seg_color.shape[1] - margin, :]
                         seg = seg[margin:seg.shape[0] - margin, margin:seg.shape[1] - margin]
 
                         mask_true[index_y_d + margin:index_y_u - margin, index_x_d + margin:index_x_u - margin] = seg
-                        prediction_true[index_y_d + margin:index_y_u - margin, index_x_d + margin:index_x_u - margin,
-                        :] = seg_color
+                        prediction_true[index_y_d + margin:index_y_u - margin, index_x_d + margin:index_x_u - margin, :] = seg_color
 
             prediction_true = prediction_true.astype(np.uint8)
-                
+
         else:
-            img_h_page=img.shape[0]
-            img_w_page=img.shape[1]
-            img = img /float( 255.0)
+            img_h_page = img.shape[0]
+            img_w_page = img.shape[1]
+            img = img / float(255.0)
             img = self.resize_image(img, img_height_model, img_width_model)
 
             label_p_pred = self.model.predict(
                 img.reshape(1, img.shape[0], img.shape[1], img.shape[2]))
 
             seg = np.argmax(label_p_pred, axis=3)[0]
-            seg_color =np.repeat(seg[:, :, np.newaxis], 3, axis=2)
+            seg_color = np.repeat(seg[:, :, np.newaxis], 3, axis=2)
             prediction_true = self.resize_image(seg_color, img_h_page, img_w_page)
             prediction_true = prediction_true.astype(np.uint8)
         return prediction_true[:,:,0]
 
     def run(self):
         self.start_new_session_and_model()
-        models_n=os.listdir(self.model_dir)
-        img_last=0
+        models_n = listdir(self.model_dir)
+        img_last = 0
         for model_in in models_n:
-            
-            res=self.predict(model_in)
 
-            img_fin=np.zeros((res.shape[0],res.shape[1],3) )
-            res[:,:][res[:,:]==0]=2
-            res=res-1
-            res=res*255
-            img_fin[:,:,0]=res
-            img_fin[:,:,1]=res
-            img_fin[:,:,2]=res
-            
-            img_fin=img_fin.astype(np.uint8)
-            img_fin=(res[:,:]==0)*255
-            img_last=img_last+img_fin
-        kernel = np.ones((5,5),np.uint8)
-        img_last[:,:][img_last[:,:]>0]=255
-        img_last=(img_last[:,:]==0)*255
-        if self.save is not None:
-            cv2.imwrite(self.save,img_last)
+            res = self.predict(model_in)
+
+            img_fin = np.zeros((res.shape[0], res.shape[1], 3))
+            res[:, :][res[:, :] == 0] = 2
+            res = res-1
+            res = res*255
+            img_fin[:, :, 0] = res
+            img_fin[:, :, 1] = res
+            img_fin[:, :, 2] = res
+
+            img_fin = img_fin.astype(np.uint8)
+            img_fin = (res[:, :] == 0)*255
+            img_last = img_last+img_fin
+
+        kernel = np.ones((5, 5), np.uint8)
+        img_last[:, :][img_last[:, :] > 0] = 255
+        img_last = (img_last[:, :] == 0)*255
+        if self.save:
+            cv2.imwrite(self.save, img_last)
+
 def main():
-    parser=argparse.ArgumentParser()
-    
-    parser.add_argument('-i','--image', dest='inp1', default=None, help='image.')
-    parser.add_argument('-p','--patches', dest='inp3', default=False, help='by setting this parameter to true you let the model to see the image in patches.')
-    parser.add_argument('-s','--save', dest='inp4', default=False, help='save prediction with a given name here. The name and format should be given (outputname.tif).')
-    parser.add_argument('-m','--model', dest='inp2', default=None, help='models directory.')
-    
-    options=parser.parse_args()
-    
-    possibles=globals()
+    parser = ArgumentParser()
+
+    parser.add_argument('-i', '--image', dest='inp1', default=None, help='image.')
+    parser.add_argument('-p', '--patches', dest='inp3', default=False, help='by setting this parameter to true you let the model to see the image in patches.')
+    parser.add_argument('-s', '--save', dest='inp4', default=False, help='save prediction with a given name here. The name and format should be given (outputname.tif).')
+    parser.add_argument('-m', '--model', dest='inp2', default=None, help='models directory.')
+
+    options = parser.parse_args()
+
+    possibles = globals()
     possibles.update(locals())
-    x=sbb_binarize(options.inp1,options.inp2,options.inp3,options.inp4)
+    x = sbb_binarize(options.inp1, options.inp2, options.inp3, options.inp4)
     x.run()
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()
-
-    
-    
-    

--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -2,18 +2,19 @@
 Tool to load model and binarize a given image.
 """
 
-from os import listdir
+import sys
+from os import listdir, environ, devnull
 from os.path import join
 from warnings import catch_warnings, simplefilter
 
 import numpy as np
 import cv2
+environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+stderr = sys.stderr
+sys.stderr = open(devnull, 'w')
 from keras.models import load_model
+sys.stderr = stderr
 import tensorflow as tf
-
-# XXX better to set env var before tensorflow import to suppress those specific warnings
-with catch_warnings():
-    simplefilter("ignore")
 
 def resize_image(img_in, input_height, input_width):
     return cv2.resize(img_in, (input_width, input_height), interpolation=cv2.INTER_NEAREST)

--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -2,7 +2,6 @@
 Tool to load model and binarize a given image.
 """
 
-from argparse import ArgumentParser
 from os import listdir
 from os.path import join
 from warnings import catch_warnings, simplefilter
@@ -16,7 +15,7 @@ import tensorflow as tf
 with catch_warnings():
     simplefilter("ignore")
 
-class sbb_binarize:
+class SbbBinarizer:
 
     # TODO use True/False for patches
     def __init__(self, image, model, patches='false', save=None):
@@ -218,21 +217,3 @@ class sbb_binarize:
         img_last = (img_last[:, :] == 0)*255
         if self.save:
             cv2.imwrite(self.save, img_last)
-
-def main():
-    parser = ArgumentParser()
-
-    parser.add_argument('-i', '--image', dest='inp1', default=None, help='image.')
-    parser.add_argument('-p', '--patches', dest='inp3', default=False, help='by setting this parameter to true you let the model to see the image in patches.')
-    parser.add_argument('-s', '--save', dest='inp4', default=False, help='save prediction with a given name here. The name and format should be given (outputname.tif).')
-    parser.add_argument('-m', '--model', dest='inp2', default=None, help='models directory.')
-
-    options = parser.parse_args()
-
-    possibles = globals()
-    possibles.update(locals())
-    x = sbb_binarize(options.inp1, options.inp2, options.inp3, options.inp4)
-    x.run()
-
-if __name__ == "__main__":
-    main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=install_requires,
     entry_points={
         'console_scripts': [
-            'sbb_binarize=sbb_binarize.sbb_binarize:main',
+            'sbb_binarize=sbb_binarize.cli:main',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     entry_points={
         'console_scripts': [
             'sbb_binarize=sbb_binarize.cli:main',
+            'ocrd-sbb-binarize=sbb_binarize.ocrd_cli:cli',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = open('requirements.txt').read().split('\n')
 setup(
     name='sbb_binarization',
     version=version,
-    description='Binarization with ',
+    description='Pixelwise binarization with selectional auto-encoders in Keras',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     author='Vahid Rezanezhad',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,28 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from json import load
+from setuptools import setup, find_packages
 
-import setuptools
-from numpy.distutils.core import Extension, setup
+with open('./ocrd-tool.json', 'r') as f:
+    version = load(f)['version']
 
-setup(name='sbb_binarize',version=1.0,packages=['sbb_binarize'])
+install_requires = open('requirements.txt').read().split('\n')
+
+setup(
+    name='sbb_binarization',
+    version=version,
+    description='Binarization with ',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    author='Vahid Rezanezhad',
+    url='https://github.com/qurator-spk/sbb_binarization',
+    license='Apache License 2.0',
+    packages=find_packages(exclude=('tests', 'docs')),
+    include_package_data=True,
+    install_requires=install_requires,
+    entry_points={
+        'console_scripts': [
+            'sbb_binarize=sbb_binarize.sbb_binarize:main',
+        ]
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     license='Apache License 2.0',
     packages=find_packages(exclude=('tests', 'docs')),
     include_package_data=True,
+    package_data={'': ['*.json', '*.yml', '*.yaml']},
     install_requires=install_requires,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
* add `setup.py`, `requirements.txt`, `Makefile`
* clean up sbb_binarizer code and split CLI into own module
* proof-of-concept OCR-D CLI

TODO:

* [x] Fix conversion from SbbBinarizer OpenCV2 image to PIL
* [x] Refactor SbbBinarizer to <del>load the model once and have a stateless `run` method</del> that is not possible because it's 4 models that are run in sequence. But SbbBinarizer is now refactored to have only model_dir as an instance var, the other args are passed to run
* [x] <del>Setup CI</del> It is set up but sbb_binarization's requires [too much RAM for binarizing two pages](https://app.circleci.com/pipelines/github/OCR-D/sbb_binarization/7/workflows/b4e90acd-5ee0-4562-adcd-5a7590594d0f/jobs/12) on Circle CI's free plan (4 GB)
* [ ] Improve documentation