### PR TITLE
combine SBB_BINARIZE_DATA and model parameter

### DIFF
--- a/sbb_binarize/ocrd-tool.json
+++ b/sbb_binarize/ocrd-tool.json
@@ -17,9 +17,9 @@
           "description": "PAGE XML hierarchy level to operate on"
         },
         "model": {
-          "description": "models directory.",
+          "description": "Directory containing HDF5 models. Can be an absolute path or a path relative to the current working directory or $SBB_BINARIZE_DATA environment variable (if set)",
           "type": "string",
-          "required": false
+          "required": true
         }
       }
     }


### PR DESCRIPTION
https://github.com/qurator-spk/sbb_binarization/pull/6

> Base the param path (if relative) on the envvar. So `model` would stay `required`, and `SBB_BINARIZE_DATA` would merely be another search path (besides CWD = workspace). Call e.g. `tar -C /my/path/to models.tar.gz; SBB_BINARIZE_DATA=/my/path/to ocrd-sbb-binarize -I OCR-D-IMG -O OCR-D-BIN -P model models`

CWD in this implementation is not the workspace directory but the actual CWD.