### PR TITLE
Fix space leak

### DIFF
--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -31,6 +31,12 @@ class SbbBinarizer:
 
         self.start_new_session()
 
+        self.model_files = glob('%s/*.h5' % self.model_dir)
+
+        self.models = []
+        for model_file in self.model_files:
+            self.models.append(self.load_model(model_file))
+
     def start_new_session(self):
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
@@ -48,8 +54,8 @@ class SbbBinarizer:
         n_classes = model.layers[len(model.layers)-1].output_shape[3]
         return model, model_height, model_width, n_classes
 
-    def predict(self, model_name, img, use_patches):
-        model, model_height, model_width, n_classes = self.load_model(model_name)
+    def predict(self, model_in, img, use_patches):
+        model, model_height, model_width, n_classes = model_in
 
         if use_patches:
 
@@ -196,12 +202,11 @@ class SbbBinarizer:
             raise ValueError("Must pass either a opencv2 image or an image_path")
         if image_path is not None:
             image = cv2.imread(image_path)
-        list_of_model_files = glob('%s/*.h5' % self.model_dir)
         img_last = 0
-        for n, model_in in enumerate(list_of_model_files):
-            self.log.info('Predicting with model %s [%s/%s]' % (model_in, n + 1, len(list_of_model_files)))
+        for n, (model, model_file) in enumerate(zip(self.models, self.model_files)):
+            self.log.info('Predicting with model %s [%s/%s]' % (model_file, n + 1, len(self.model_files)))
 
-            res = self.predict(model_in, image, use_patches)
+            res = self.predict(model, image, use_patches)
 
             img_fin = np.zeros((res.shape[0], res.shape[1], 3))
             res[:, :][res[:, :] == 0] = 2

--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -29,6 +29,8 @@ class SbbBinarizer:
         self.model_dir = model_dir
         self.log = logger if logger else logging.getLogger('SbbBinarizer')
 
+        self.start_new_session()
+
     def start_new_session(self):
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
@@ -194,7 +196,6 @@ class SbbBinarizer:
             raise ValueError("Must pass either a opencv2 image or an image_path")
         if image_path is not None:
             image = cv2.imread(image_path)
-        self.start_new_session()
         list_of_model_files = glob('%s/*.h5' % self.model_dir)
         img_last = 0
         for n, model_in in enumerate(list_of_model_files):


### PR DESCRIPTION
It looks like sbb-binarization uses a lot more memory than it needs, potentially leading the host machine to run out of memory depending on the available RAM and the size of the workflow.

Let `k` be the number of models used and `n` be the number of images in the workflow. By looking at the code we can see that:

1) The program instantiates `n` tensorflow session objects despite needing only 1;
2) The program instantiates `kn` model objects despite needing only `k`.

These issues are solved by moving some routines called directly or indirectly by the `run` method to the `__init__` method. I ran memory profilings (valgrind massif) of sbb-binarization both with and without the changes proposed in this PR using the [DIBCO11 assets provided by OCR-D](https://github.com/OCR-D/assets/tree/32fde9eb242c595a1986a193090c689f52eeb734/data/DIBCO11-machine_printed/data) and plotted the data with matplotlib to demonstrate (check [massif.zip](https://github.com/qurator-spk/sbb_binarization/files/5472082/massif.zip) for the actual massif.out files).

![msparse](https://user-images.githubusercontent.com/33208157/97819156-9589db80-1c85-11eb-9bfe-a1e0a6696d52.png)

The unnecessary memory allocations causes sbb-binarization's RAM usage to gradually increase over time,  reaching over 7GB in the end. With this PR, the memory consumption stabilizes around 1GB. The process also takes only 84% of the original time to finish since a lot of instantiation routines are not unnecessarily repeated.