### PR TITLE
require tensorflow-gpu instead of tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ opencv-python-headless
 ocrd >= 2.18.0
 keras >= 2.3.1, < 2.4
 h5py < 3
-tensorflow >= 1.15, < 1.16
+tensorflow-gpu >= 1.15, < 1.16


### PR DESCRIPTION
TF has changed its convention back and forth regarding GPU opt in/out, but seems to be stable at the following now:
- pre v2: `tensorflow-gpu` for CPU+GPU, `tensorflow` for CPU-only
- post v2: `tensorflow` for CPU+GPU

So it should be `tensorflow-gpu` here.

See https://github.com/OCR-D/ocrd_all/issues/220.