### PR TITLE
Factor setup

### DIFF
--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -15,6 +15,7 @@ environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 stderr = sys.stderr
 sys.stderr = open(devnull, 'w')
 from keras.models import load_model
+from keras.backend import tensorflow_backend
 sys.stderr = stderr
 import tensorflow as tf
 
@@ -42,8 +43,10 @@ class SbbBinarizer:
         config.gpu_options.allow_growth = True
 
         self.session = tf.Session(config=config)  # tf.InteractiveSession()
+        tensorflow_backend.set_session(self.session)
 
     def end_session(self):
+        tensorflow_backend.clear_session()
         self.session.close()
         del self.session
 
@@ -55,6 +58,7 @@ class SbbBinarizer:
         return model, model_height, model_width, n_classes
 
     def predict(self, model_in, img, use_patches):
+        tensorflow_backend.set_session(self.session)
         model, model_height, model_width, n_classes = model_in
         
         img_org_h = img.shape[0]


### PR DESCRIPTION
In preparation of [upcoming API changes](https://hackmd.io/23-JzLp_Q96cb6T0ttoFIA) – notably automatic page-level parallelism and page-level failover – this factors out the model loading from `process()` and from the constructor into a dedicated, conventional `setup()` (which will be required/used by the Processor base class in core soon, at which point there will be no need to call it from the inherited constructor).

Note that this also already enables running sbb-binarize in the [workflow server prototype](https://github.com/OCR-D/core/pull/652).

The second change is necessary if you have multiple TF sessions in your server: each must store its session and reload it just prior to running the graph.