### PR TITLE
actually use TF2 (with TF1.compat mode)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ opencv-python-headless
 ocrd >= 2.22.3
 keras >= 2.3.1, < 2.4
 h5py < 3
-tensorflow-gpu >= 1.15, < 1.16
+tensorflow-gpu >= 2.4.0


### PR DESCRIPTION
https://github.com/qurator-spk/sbb_binarization/commit/416b5dd7e27af299bc5fed54669c24ee1f2bcc15 introduced the use of `tf.compat.v1` 