### PR TITLE
depend on tensorflow not tensorflow-gpu, drop holding h5py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy
 setuptools >= 41
 opencv-python-headless
 ocrd >= 2.22.3
-h5py < 3
-tensorflow-gpu >= 2.4.0
+tensorflow >= 2.4.0


### PR DESCRIPTION
- `tensorflow-gpu` seems to end at 2.4 line, while `tensorflow` is currently at 2.6
- h5py v2 was only necessary for Keras models in TF1 IIRC