### PR TITLE
use types.Path instead of click.Path to avoid NameError

### DIFF
--- a/sbb_binarize/cli.py
+++ b/sbb_binarize/cli.py
@@ -8,7 +8,7 @@ from .sbb_binarize import SbbBinarizer
 @command()
 @version_option()
 @option('--patches/--no-patches', default=True, help='by enabling this parameter you let the model to see the image in patches.')
-@option('--model-dir', '-m', type=click.Path(exists=True, file_okay=False), required=True, help='directory containing models for prediction')
+@option('--model-dir', '-m', type=types.Path(exists=True, file_okay=False), required=True, help='directory containing models for prediction')
 @argument('input_image')
 @argument('output_image')
 def main(patches, model_dir, input_image, output_image):


### PR DESCRIPTION
Fixes a problem introduced by 0877199c68a318067935d57a088f9bcf1afac8c2 where `import click` was removed (as importing `types` from click is sufficient) but w/o removing references to the `click` namespace in the code.
This leads to a `NameError` when calling the CLI, replacing `click.Path` with `types.Path` resolves this.