### PR TITLE
Raise error when no models were loaded

### DIFF
--- a/sbb_binarize/sbb_binarize.py
+++ b/sbb_binarize/sbb_binarize.py
@@ -34,7 +34,9 @@ class SbbBinarizer:
         self.start_new_session()
 
         self.model_files = glob('%s/*.h5' % self.model_dir)
-
+        if not self.model_files:
+            raise ValueError(f"No models found in {self.model_dir}")
+        
         self.models = []
         for model_file in self.model_files:
             self.models.append(self.load_model(model_file))


### PR DESCRIPTION
Small fix to raise an exception when no model was found instead of failing later with TypeError: 'int' object is not subscriptable.

Fixes #30 