### PR TITLE
Pinning library versions and adding Python version to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 /build
 /dist
+/.idea/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Clone the repository, enter it and run
 
 `pip install .`
 
+### Requirements
+
+This project has been tested with Python 3.6 and the library versions specified in the requirements.txt, but might also work with later versions of Tensorflow.
+
 ### Models
 
 Pre-trained models in  `HDF5` format can be downloaded from here:   

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 setuptools>=41
-ocrd==2.38.0
+ocrd>=2.22.3
 opencv-python-headless==4.6.0.66
 tensorflow >= 2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-setuptools >= 41
-opencv-python-headless
-ocrd >= 2.38.0
+setuptools>=41
+ocrd==2.38.0
+opencv-python-headless==4.6.0.66
 tensorflow >= 2.4.0


### PR DESCRIPTION
This PR updates the requirements.txt (to pin specifically tested versions that actually work) as well as adding a tested Python version information to the README. Later versions will not work because of loading serialized h5 models causes marshalling errors.

Also adding `.idea` directory to list of ignored directories.

Fixes #39 
